### PR TITLE
Refactor pipeline parameters and add ATR calculator

### DIFF
--- a/SmartCFDTradingAgent/backtester.py
+++ b/SmartCFDTradingAgent/backtester.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple
 
 import pandas as pd, numpy as np
 
-from SmartCFDTradingAgent.indicators import atr
+from SmartCFDTradingAgent.calculator import atr
 
 def _sig_to_pos(sig: str) -> int:
     return {"Buy": 1, "Sell": -1}.get(sig, 0)

--- a/SmartCFDTradingAgent/calculator.py
+++ b/SmartCFDTradingAgent/calculator.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+import pandas as pd
+
+def atr(high: pd.Series, low: pd.Series, close: pd.Series, period: int = 14) -> pd.Series:
+    """Average True Range (ATR) indicator."""
+    tr = pd.concat(
+        [high - low, (high - close.shift()).abs(), (low - close.shift()).abs()],
+        axis=1,
+    ).max(axis=1)
+    return tr.rolling(period).mean()
+
+__all__ = ["atr"]

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+
+def test_main_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "SmartCFDTradingAgent.__main__", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- align pipeline with new qty/risk ordering and forward risk from CLI
- add calculator module exposing `atr` and update backtester import
- exercise `python -m SmartCFDTradingAgent.__main__ --help` via new smoke test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b419dfffb083309cea361f9d6be180