### PR TITLE
Conditionally apply SSL bypass

### DIFF
--- a/SmartCFDTradingAgent/__main__.py
+++ b/SmartCFDTradingAgent/__main__.py
@@ -1,4 +1,10 @@
 from __future__ import annotations
+
+import os
+
+if os.getenv("SKIP_SSL_VERIFY") == "1":
+    import SmartCFDTradingAgent.utils.no_ssl  # noqa: F401
+
 import argparse, datetime as dt
 from SmartCFDTradingAgent.data_loader import get_price_data
 from SmartCFDTradingAgent.signals import generate_signals

--- a/SmartCFDTradingAgent/data_loader.py
+++ b/SmartCFDTradingAgent/data_loader.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import SmartCFDTradingAgent.utils.no_ssl  # ensure SSL bypass before yfinance usage
 
 import hashlib
 import os

--- a/SmartCFDTradingAgent/pipeline.py
+++ b/SmartCFDTradingAgent/pipeline.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-# Must be first: force yfinance to use safe downloader (no SSL issues)
-import SmartCFDTradingAgent.utils.no_ssl  # noqa: F401
-
 import os
-os.environ.setdefault("CURL_CA_BUNDLE", "")
-os.environ.setdefault("YF_DISABLE_CURL", "1")
+
+if os.getenv("SKIP_SSL_VERIFY") == "1":
+    import SmartCFDTradingAgent.utils.no_ssl  # noqa: F401
 
 import argparse, time, datetime as dt, csv, sys, json
 from dotenv import load_dotenv

--- a/SmartCFDTradingAgent/rank_assets.py
+++ b/SmartCFDTradingAgent/rank_assets.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import SmartCFDTradingAgent.utils.no_ssl  # must be first
 
 import argparse
 import datetime as dt

--- a/SmartCFDTradingAgent/walk_forward.py
+++ b/SmartCFDTradingAgent/walk_forward.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import SmartCFDTradingAgent.utils.no_ssl  # must be first
+
 import argparse, datetime as dt, json
 from pathlib import Path
 import pandas as pd

--- a/tests/test_ssl_toggle.py
+++ b/tests/test_ssl_toggle.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.mark.parametrize("skip", ["0", "1"])
+def test_download_smoke(monkeypatch, skip):
+    monkeypatch.setenv("SKIP_SSL_VERIFY", skip)
+    sys.modules.pop("SmartCFDTradingAgent.pipeline", None)
+    sys.modules.pop("SmartCFDTradingAgent.utils.no_ssl", None)
+
+    import SmartCFDTradingAgent.pipeline  # noqa: F401
+    import SmartCFDTradingAgent.data_loader as dl
+
+    def fake_download(*args, **kwargs):
+        idx = pd.date_range("2024-01-01", periods=1)
+        data = {f: [1] for f in [
+            "Open",
+            "High",
+            "Low",
+            "Close",
+            "Adj Close",
+            "Volume",
+        ]}
+        return pd.DataFrame(data, index=idx)
+
+    monkeypatch.setattr(dl, "_download", fake_download)
+
+    df = dl.get_price_data(["AAPL"], "2024-01-01", "2024-01-02")
+    assert not df.empty
+
+    imported = "SmartCFDTradingAgent.utils.no_ssl" in sys.modules
+    assert imported == (skip == "1")
+


### PR DESCRIPTION
## Summary
- Import `no_ssl` only when `SKIP_SSL_VERIFY=1` in pipeline and CLI entrypoint
- Remove direct SSL bypass imports from modules that load data or ranking
- Add smoke test covering download with and without SSL verification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b419e537888330aa1a2e21596d60d7