### PR TITLE
Use return volatility ratio for asset ranking

### DIFF
--- a/SmartCFDTradingAgent/rank_assets.py
+++ b/SmartCFDTradingAgent/rank_assets.py
@@ -3,147 +3,75 @@ import SmartCFDTradingAgent.utils.no_ssl  # must be first
 
 import argparse
 import datetime as dt
-from typing import Dict, Iterable, List
+from typing import Iterable, List
 
 import pandas as pd
 
 from SmartCFDTradingAgent.data_loader import get_price_data
 
 
-def _sharpe(close: pd.Series, lb: int) -> float:
-    r = close.pct_change().dropna().tail(lb)
-    if len(r) < 2:
-        return 0.0
-    return (r.mean() / (r.std() or 1e-9)) * (252 ** 0.5)
-
-
-def _momentum(close: pd.Series, lb: int) -> float:
-    if len(close) <= lb:
-        return 0.0
-    start = close.iloc[-lb]
-    end = close.iloc[-1]
-    return (end / start) - 1.0
-
-
-def _avg_volume(volume: pd.Series, lb: int) -> float:
-    return volume.tail(lb).mean() if not volume.empty else 0.0
-
-
-def _volatility(close: pd.Series, lb: int) -> float:
-    r = close.pct_change().dropna().tail(lb)
-    return r.std() * (252 ** 0.5) if not r.empty else 0.0
-
-
 def top_n(
     tickers: Iterable[str],
     n: int,
     *,
-    lookbacks: Dict[str, int] | None = None,
-    weights: Dict[str, float] | None = None,
+    lookback: int = 60,
+    min_dollar_volume: float = 0.0,
 ) -> List[str]:
-    """Rank tickers by composite score and return the top ``n``.
+    """Rank tickers by simple return-based score and return the top ``n``.
 
-    Parameters
-    ----------
-    tickers:
-        Iterable of ticker symbols.
-    n:
-        Number of tickers to return.
-    lookbacks:
-        Optional dict specifying lookback windows for metrics.
-        Keys: ``sharpe``, ``momentum``, ``volume``, ``volatility``.
-    weights:
-        Optional dict specifying weights for metrics. Same keys as above.
+    The score is defined as ``mean(returns) / std(returns)`` over the last
+    ``lookback`` bars. Tickers whose median dollar volume over the same period
+    falls below ``min_dollar_volume`` are excluded before ranking.
     """
 
     tickers = list(dict.fromkeys(tickers))
     if not tickers:
         return []
 
-    lookbacks = {
-        "sharpe": 30,
-        "momentum": 252,
-        "volume": 30,
-        "volatility": 30,
-        **(lookbacks or {}),
-    }
-
-    weights = {
-        "sharpe": 0.4,
-        "momentum": 0.3,
-        "volume": 0.2,
-        "volatility": -0.1,
-        **(weights or {}),
-    }
-
     end = dt.date.today().isoformat()
-    max_lb = max(lookbacks.values())
-    start = (dt.date.today() - dt.timedelta(days=max_lb + 5)).isoformat()
+    start = (dt.date.today() - dt.timedelta(days=lookback + 5)).isoformat()
 
     try:
         df = get_price_data(tickers, start, end, interval="1d")
     except Exception as e:
         print(
-            f"[rank_assets] daily ranking failed ({e}); returning unranked first {n}."
+            f"[rank_assets] daily ranking failed ({e}); returning unranked first {n}.",
         )
         return tickers[: min(n, len(tickers))]
 
-    metrics = {k: {} for k in lookbacks}
-
+    scores: dict[str, float] = {}
     for t in tickers:
         try:
             close = df[t]["Close"].dropna()
             volume = df[t].get("Volume", pd.Series(dtype=float)).dropna()
 
-            metrics["sharpe"][t] = _sharpe(close, lookbacks["sharpe"])
-            metrics["momentum"][t] = _momentum(close, lookbacks["momentum"])
-            metrics["volume"][t] = _avg_volume(volume, lookbacks["volume"])
-            metrics["volatility"][t] = _volatility(close, lookbacks["volatility"])
+            ret = close.pct_change().dropna().tail(lookback)
+            if ret.empty:
+                continue
+
+            med_dollar_vol = (close.tail(lookback) * volume.tail(lookback)).median()
+            if pd.isna(med_dollar_vol) or med_dollar_vol < min_dollar_volume:
+                continue
+
+            scores[t] = ret.mean() / (ret.std() or 1e-9)
         except Exception:
-            for m in metrics:
-                metrics[m][t] = float("nan")
-
-    scores: Dict[str, float] = {t: 0.0 for t in tickers}
-    for name, vals in metrics.items():
-        series = pd.Series(vals)
-        if series.isna().all():
             continue
-        z = (series - series.mean()) / (series.std() or 1e-9)
-        w = weights.get(name, 0.0)
-        for t in tickers:
-            scores[t] += z.get(t, 0.0) * w
 
-    ranked = sorted(tickers, key=lambda t: scores.get(t, -1e9), reverse=True)
+    ranked = sorted(scores, key=lambda t: scores[t], reverse=True)
     return ranked[: min(n, len(ranked))]
-
-
-def _parse_weights(s: str) -> Dict[str, float]:
-    out: Dict[str, float] = {}
-    if not s:
-        return out
-    for part in s.split(","):
-        if "=" not in part:
-            continue
-        k, v = part.split("=", 1)
-        try:
-            out[k.strip()] = float(v)
-        except ValueError:
-            pass
-    return out
 
 
 def main(argv: Iterable[str] | None = None) -> None:
     ap = argparse.ArgumentParser("rank_assets")
     ap.add_argument("tickers", nargs="*", help="Tickers to rank")
     ap.add_argument("-n", "--top", type=int, default=5, help="Number of tickers")
-    ap.add_argument("--sharpe-lookback", type=int, default=30)
-    ap.add_argument("--momentum-lookback", type=int, default=252)
-    ap.add_argument("--volume-lookback", type=int, default=30)
-    ap.add_argument("--volatility-lookback", type=int, default=30)
+    ap.add_argument("--lookback", type=int, default=60, help="Lookback window in bars")
     ap.add_argument(
-        "--weights",
-        default="",
-        help="Comma-separated weights, e.g. sharpe=0.4,momentum=0.3",
+        "--min-dollar-volume",
+        type=float,
+        default=0.0,
+        dest="min_dollar_volume",
+        help="Minimum median dollar volume over lookback window",
     )
     ap.add_argument("--config", help="Path to config file")
     ap.add_argument("--profile", help="Profile name inside config")
@@ -158,19 +86,15 @@ def main(argv: Iterable[str] | None = None) -> None:
 
     tickers = args.tickers or cfg.get("tickers", [])
     topn = args.top if args.top != ap.get_default("top") else cfg.get("top", args.top)
+    lookback = cfg.get("lookback", args.lookback)
+    min_dollar_volume = cfg.get("min_dollar_volume", args.min_dollar_volume)
 
-    lookbacks = {
-        "sharpe": cfg.get("sharpe_lookback", args.sharpe_lookback),
-        "momentum": cfg.get("momentum_lookback", args.momentum_lookback),
-        "volume": cfg.get("volume_lookback", args.volume_lookback),
-        "volatility": cfg.get("volatility_lookback", args.volatility_lookback),
-    }
-
-    weights = cfg.get("weights", {})
-    cli_weights = _parse_weights(args.weights)
-    weights.update(cli_weights)
-
-    ranked = top_n(tickers, topn, lookbacks=lookbacks, weights=weights)
+    ranked = top_n(
+        tickers,
+        topn,
+        lookback=lookback,
+        min_dollar_volume=min_dollar_volume,
+    )
     print(ranked)
 
 

--- a/tests/test_rank_assets.py
+++ b/tests/test_rank_assets.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 # Ensure project root on path
@@ -9,32 +10,35 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from SmartCFDTradingAgent import rank_assets
 
 
-def test_top_n_composite_ranking(monkeypatch):
+def test_ranking_and_liquidity_filter(monkeypatch):
     tickers = ["AAA", "BBB", "CCC"]
-    idx = pd.date_range("2020-01-01", periods=10, freq="D")
+    idx = pd.date_range("2020-01-01", periods=61, freq="D")
     arrays = pd.MultiIndex.from_product([tickers, ["Close", "Volume"]])
-    df = pd.DataFrame(index=idx, columns=arrays)
+    df = pd.DataFrame(index=idx, columns=arrays, dtype=float)
 
-    # AAA: strong momentum, high volume, low volatility
-    df["AAA", "Close"] = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-    df["AAA", "Volume"] = [100] * 10
+    # AAA: strong constant returns, high volume
+    df["AAA", "Close"] = 100 * (1.05) ** np.arange(len(idx))
+    df["AAA", "Volume"] = 1000
 
-    # BBB: negative momentum, medium volume, high volatility
-    df["BBB", "Close"] = [10, 8, 12, 9, 13, 8, 14, 7, 15, 6]
-    df["BBB", "Volume"] = [50] * 10
+    # BBB: modest constant returns, high volume
+    df["BBB", "Close"] = 100 * (1.02) ** np.arange(len(idx))
+    df["BBB", "Volume"] = 1000
 
-    # CCC: flat, low volume, very low volatility
-    df["CCC", "Close"] = [10] * 10
-    df["CCC", "Volume"] = [10] * 10
+    # CCC: positive returns but extremely low volume (to be excluded)
+    df["CCC", "Close"] = 100 * (1.01) ** np.arange(len(idx))
+    df["CCC", "Volume"] = 1
 
     def fake_get_price_data(tickers, start, end, interval="1d"):
         return df
 
     monkeypatch.setattr(rank_assets, "get_price_data", fake_get_price_data)
 
-    lookbacks = {"sharpe": 5, "momentum": 5, "volume": 5, "volatility": 5}
-    weights = {"sharpe": 0.0, "momentum": 0.5, "volume": 0.3, "volatility": -0.2}
+    ranked = rank_assets.top_n(
+        tickers,
+        3,
+        lookback=60,
+        min_dollar_volume=100_000,
+    )
 
-    ranked = rank_assets.top_n(tickers, 3, lookbacks=lookbacks, weights=weights)
-    assert ranked == ["AAA", "CCC", "BBB"]
+    assert ranked == ["AAA", "BBB"]
 


### PR DESCRIPTION
## Summary
- replace composite metric ranking with mean(return)/std(return) score
- filter illiquid tickers by median dollar volume before ranking
- add synthetic test covering ranking order and liquidity exclusion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b419e9420483308a18d5f5d769dc48