### PR TITLE
feat: add watchlist check in pipeline run_cycle

### DIFF
--- a/SmartCFDTradingAgent/pipeline.py
+++ b/SmartCFDTradingAgent/pipeline.py
@@ -395,7 +395,9 @@ def run_cycle(
     dry_run: bool = False,
 ):
     equity = qty
-    …
+    if not watch:
+        log.info("Watchlist empty – skipping cycle.")
+        return
 
 
     # Market hours gate (skip if equity market closed unless it's crypto-only or --force)


### PR DESCRIPTION
## Summary
- ensure run_cycle exits early when watchlist is empty

## Testing
- `python -m SmartCFDTradingAgent.pipeline` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b429b3849883308670e0a327d2be97