### PR TITLE
Add daily trade summary reporting

### DIFF
--- a/scripts/daily_summary.py
+++ b/scripts/daily_summary.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Send a daily trade summary via Telegram."""
+
+from SmartCFDTradingAgent.utils.trade_logger import aggregate_trade_stats
+from SmartCFDTradingAgent.utils import telegram
+
+
+def main() -> None:
+    stats = aggregate_trade_stats()
+    message = (
+        "Daily summary\n"
+        f"Wins: {stats['wins']}\n"
+        f"Losses: {stats['losses']}\n"
+        f"Open trades: {stats['open']}"
+    )
+    telegram.send(message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `aggregate_trade_stats` to compute wins, losses and open positions from the trade log
- Add `scripts/daily_summary.py` to send a Telegram summary of trade results

## Testing
- `pytest`
- ❌ `crontab` (command not found)
- ❌ `apt-get update` (403: Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b42ea1ab0c8330bfa8c002b8d1cea9