### PR TITLE
Add trade-log driven retraining to pipeline

### DIFF
--- a/SmartCFDTradingAgent/pipeline.py
+++ b/SmartCFDTradingAgent/pipeline.py
@@ -677,6 +677,12 @@ def run_cycle(
     if limits_hit:
         summary += " | limits: " + ",".join(sorted(limits_hit))
     safe_send(summary)
+    if not dry_run:
+        try:
+            from SmartCFDTradingAgent.walk_forward import retrain_from_trade_log
+            retrain_from_trade_log()
+        except Exception as e:  # pragma: no cover - best effort
+            log.error("Retraining failed: %s", e)
     return pnl, stats, summary
 
 def main():

--- a/SmartCFDTradingAgent/walk_forward.py
+++ b/SmartCFDTradingAgent/walk_forward.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
-import argparse, datetime as dt, json
+import argparse, datetime as dt, json, sqlite3
 from pathlib import Path
 import pandas as pd
 from SmartCFDTradingAgent.data_loader import get_price_data
 from SmartCFDTradingAgent.indicators import ema, macd, adx
+from SmartCFDTradingAgent.utils import trade_logger
+
+try:  # optional dependency
+    from SmartCFDTradingAgent.ml_models import PriceDirectionModel
+except Exception:  # pragma: no cover - model training optional
+    PriceDirectionModel = None  # type: ignore
 
 STORE = Path(__file__).resolve().parent / "storage"
 STORE.mkdir(exist_ok=True)
+
 
 def _tz_naive_index(idx: pd.DatetimeIndex) -> pd.DatetimeIndex:
     try:
@@ -15,79 +22,80 @@ def _tz_naive_index(idx: pd.DatetimeIndex) -> pd.DatetimeIndex:
     except Exception:
         return idx
 
+
 def score_segment(df_tkr: pd.DataFrame, adx_th: int, sl=0.02, tp=0.04, ema_fast=12, ema_slow=26) -> float:
-    """
-    Very fast pseudo-backtest score on a price segment.
-    """
+    """Very fast pseudo-backtest score on a price segment."""
     high, low, close = df_tkr["High"], df_tkr["Low"], df_tkr["Close"]
     rets = close.pct_change().fillna(0.0)
     f, s = ema(close, ema_fast), ema(close, ema_slow)
     m = macd(close)
     a = adx(high, low, close).fillna(0)
-    pos = 0; score = 0.0; hold = 0
+    pos = 0
+    score = 0.0
+    hold = 0
     for i in range(1, len(close)):
         hist = m["hist"].iloc[i]
-        cond_buy  = (f.iloc[i] > s.iloc[i]) and (hist > 0) and (a.iloc[i] >= adx_th)
+        cond_buy = (f.iloc[i] > s.iloc[i]) and (hist > 0) and (a.iloc[i] >= adx_th)
         cond_sell = (f.iloc[i] < s.iloc[i]) and (hist < 0) and (a.iloc[i] >= adx_th)
         sig = 1 if cond_buy else (-1 if cond_sell else 0)
         if pos == 0 and sig != 0:
-            pos = sig; hold = 0; score -= 0.0002  # entry cost
+            pos = sig
+            hold = 0
+            score -= 0.0002  # entry cost
             continue
         if pos != 0:
             hold += 1
             r = rets.iloc[i] * pos
             score += r
             if r <= -sl or r >= tp or hold >= 5:
-                pos = 0; score -= 0.0002        # exit cost
+                pos = 0
+                score -= 0.0002  # exit cost
     return float(score)
 
+
 def make_monthly_windows(idx: pd.DatetimeIndex, train_months=6, test_months=1):
-    """
-    Yield (train_start, train_end, test_start, test_end) date tuples.
-    """
+    """Yield (train_start, train_end, test_start, test_end) date tuples."""
     if len(idx) == 0:
         return
     idx = _tz_naive_index(idx)
     first = idx.min().to_period("M").to_timestamp()
-    last  = idx.max().to_period("M").to_timestamp() + pd.offsets.MonthEnd(1)
-    cur   = first
+    last = idx.max().to_period("M").to_timestamp() + pd.offsets.MonthEnd(1)
+    cur = first
     while True:
         tr_start = cur
-        tr_end   = tr_start + pd.offsets.MonthEnd(train_months)
+        tr_end = tr_start + pd.offsets.MonthEnd(train_months)
         te_start = tr_end
-        te_end   = te_start + pd.offsets.MonthEnd(test_months)
+        te_end = te_start + pd.offsets.MonthEnd(test_months)
         if te_end > last:
             break
         yield (tr_start, tr_end, te_start, te_end)
         cur = cur + pd.offsets.MonthBegin(test_months)
 
+
 def optimize_walk_forward(df: pd.DataFrame, train_months=6, test_months=1):
-    """
-    Evaluate each param combo across rolling folds and return the combo with the
-    best average TEST score across folds.
-    """
-    adx_grid      = [8, 10, 12, 15, 20]
-    sl_grid       = [0.015, 0.02, 0.03]
-    tp_grid       = [0.03, 0.04, 0.06]
+    """Evaluate each param combo across rolling folds and return the combo with the best average TEST score."""
+    adx_grid = [8, 10, 12, 15, 20]
+    sl_grid = [0.015, 0.02, 0.03]
+    tp_grid = [0.03, 0.04, 0.06]
     ema_fast_grid = [8, 12]
     ema_slow_grid = [20, 26]
 
-    combos = [(adx_th, sl, tp, f, s)
-              for adx_th in adx_grid
-              for sl in sl_grid
-              for tp in tp_grid
-              for f in ema_fast_grid
-              for s in ema_slow_grid]
+    combos = [
+        (adx_th, sl, tp, f, s)
+        for adx_th in adx_grid
+        for sl in sl_grid
+        for tp in tp_grid
+        for f in ema_fast_grid
+        for s in ema_slow_grid
+    ]
 
-    # Fold results
     results: dict[tuple, list[float]] = {c: [] for c in combos}
 
     idx_union = df.index
     for (tr_start, tr_end, te_start, te_end) in make_monthly_windows(idx_union, train_months, test_months):
-        # TRAIN: pick the best combo on this window
         best_combo, best_train = None, -1e9
         seg_train = df.loc[(df.index >= tr_start) & (df.index < tr_end)]
-        seg_test  = df.loc[(df.index >= te_start) & (df.index < te_end)]
+        seg_test = df.loc[(df.index >= te_start) & (df.index < te_end)]
         if len(seg_train) < 50 or len(seg_test) < 20:
             continue
         for c in combos:
@@ -95,13 +103,11 @@ def optimize_walk_forward(df: pd.DataFrame, train_months=6, test_months=1):
             tr_sc = score_segment(seg_train, adx_th, sl, tp, f, s)
             if tr_sc > best_train:
                 best_train, best_combo = tr_sc, c
-        # TEST: evaluate chosen combo on test segment
         if best_combo is not None:
             adx_th, sl, tp, f, s = best_combo
             te_sc = score_segment(seg_test, adx_th, sl, tp, f, s)
             results[best_combo].append(te_sc)
 
-    # Average across folds
     best_c, best_avg = None, -1e9
     for c, lst in results.items():
         if lst:
@@ -110,10 +116,92 @@ def optimize_walk_forward(df: pd.DataFrame, train_months=6, test_months=1):
                 best_avg, best_c = avg, c
 
     if best_c is None:
-        # Fallback sane defaults
         return {"adx": 12, "sl": 0.02, "tp": 0.04, "ema_fast": 12, "ema_slow": 26, "wf_avg": 0.0, "folds": 0}
     adx_th, sl, tp, f, s = best_c
-    return {"adx": adx_th, "sl": sl, "tp": tp, "ema_fast": f, "ema_slow": s, "wf_avg": round(best_avg, 6), "folds": len(results[best_c])}
+    return {
+        "adx": adx_th,
+        "sl": sl,
+        "tp": tp,
+        "ema_fast": f,
+        "ema_slow": s,
+        "wf_avg": round(best_avg, 6),
+        "folds": len(results[best_c]),
+    }
+
+
+def retrain_from_trade_log(years: int = 1, interval: str = "1d") -> None:
+    """Rebuild walk-forward params and retrain the ML model from trade logs."""
+    db_path = trade_logger.DB_PATH
+    store = db_path.parent
+    if not db_path.exists():
+        return
+
+    stamp = store / "last_retrain.txt"
+    try:
+        if stamp.exists():
+            mtime = dt.datetime.fromtimestamp(stamp.stat().st_mtime)
+            if (dt.datetime.utcnow() - mtime).total_seconds() < 24 * 3600:
+                return
+    except Exception:
+        pass
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT DISTINCT ticker FROM trades")
+        tickers = [r[0] for r in cur.fetchall() if r and r[0]]
+    finally:
+        conn.close()
+    if not tickers:
+        return
+
+    end = dt.date.today().isoformat()
+    start = (dt.date.today() - dt.timedelta(days=365 * years)).isoformat()
+    df = get_price_data(tickers, start, end, interval=interval)
+
+    params_path = store / "params.json"
+    try:
+        obj = json.loads(params_path.read_text(encoding="utf-8")) if params_path.exists() else {}
+    except Exception:
+        obj = {}
+
+    if isinstance(df.columns, pd.MultiIndex):
+        for t in tickers:
+            try:
+                one = df[t].dropna(how="all")
+            except Exception:
+                continue
+            if len(one) < 80:
+                continue
+            best = optimize_walk_forward(one)
+            obj[f"{t}|{interval}"] = best
+    else:
+        best = optimize_walk_forward(df)
+        if tickers:
+            obj[f"{tickers[0]}|{interval}"] = best
+
+    try:
+        params_path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
+    except Exception:
+        pass
+
+    if PriceDirectionModel is not None:
+        try:
+            if isinstance(df.columns, pd.MultiIndex):
+                close = df.xs("Close", level=1, axis=1).mean(axis=1)
+            else:
+                close = df["Close"]
+            model = PriceDirectionModel()
+            model.fit(close.to_frame("Close"))
+            model.save(store / "ml_model.pkl")
+        except Exception:
+            pass
+
+    try:
+        stamp.write_text(dt.datetime.utcnow().isoformat(), encoding="utf-8")
+    except Exception:
+        pass
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -126,7 +214,7 @@ def main():
     args = ap.parse_args()
 
     end = dt.date.today().isoformat()
-    start = (dt.date.today() - dt.timedelta(days=365*args.years)).isoformat()
+    start = (dt.date.today() - dt.timedelta(days=365 * args.years)).isoformat()
     df = get_price_data(args.watch, start, end, interval=args.interval)
 
     params_path = STORE / "params.json"
@@ -135,7 +223,6 @@ def main():
     except Exception:
         obj = {}
 
-    # Per-ticker mode
     if isinstance(df.columns, pd.MultiIndex) and args.per_ticker:
         tickers = sorted({c[0] for c in df.columns})
         for t in tickers:
@@ -147,7 +234,6 @@ def main():
             obj[key] = best
             print("Walk-forward (per-ticker) saved:", key, "=>", best)
     else:
-        # Group mode (original behavior)
         best = optimize_walk_forward(df, args.train_months, args.test_months)
         key = ",".join(sorted(args.watch)) + "|" + args.interval
         obj[key] = best
@@ -155,5 +241,7 @@ def main():
 
     params_path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
 
+
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add `retrain_from_trade_log` helper to rebuild params and ML model from `trade_log.sqlite`
- trigger model/parameter retraining after live pipeline cycles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42ea317a4833098e0a7d8c28c4e8d