### PR TITLE
Add Alpaca broker with paper trading support

### DIFF
--- a/SmartCFDTradingAgent/brokers/__init__.py
+++ b/SmartCFDTradingAgent/brokers/__init__.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from .manual import ManualBroker
+from .alpaca import AlpacaBroker
 
 
 def get_broker(name: str):
     name = (name or "").lower()
     if name == "manual":
         return ManualBroker()
+    if name == "alpaca":
+        return AlpacaBroker()
     raise ValueError(f"Unknown broker: {name}")

--- a/SmartCFDTradingAgent/brokers/alpaca.py
+++ b/SmartCFDTradingAgent/brokers/alpaca.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+try:  # pragma: no cover - handled in tests via monkeypatch
+    import alpaca_trade_api as tradeapi
+except Exception:  # pragma: no cover
+    tradeapi = None  # type: ignore
+
+from .base import Broker
+
+
+class AlpacaBroker(Broker):
+    """Broker implementation using Alpaca's paper trading API."""
+
+    def __init__(
+        self,
+        key_id: str | None = None,
+        secret_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        if tradeapi is None:  # pragma: no cover - dependency missing
+            raise RuntimeError("alpaca-trade-api package required")
+        self.log = logging.getLogger("alpaca-broker")
+        self.api = tradeapi.REST(
+            key_id or os.getenv("APCA_API_KEY_ID"),
+            secret_key or os.getenv("APCA_API_SECRET_KEY"),
+            base_url or os.getenv("APCA_API_BASE_URL", "https://paper-api.alpaca.markets"),
+            api_version="v2",
+        )
+
+    # --- helper methods ---
+    def get_equity(self) -> float:
+        """Return account equity from Alpaca."""
+        acct = self.api.get_account()
+        try:
+            return float(getattr(acct, "equity", 0.0))
+        except Exception:
+            return 0.0
+
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        entry: float | None = None,
+        sl: float | None = None,
+        tp: float | None = None,
+        trail_atr: float | None = None,
+        tif: str = "day",
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        order: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "entry": entry,
+            "sl": sl,
+            "tp": tp,
+            "trail_atr": trail_atr,
+            "tif": tif,
+            "dry_run": dry_run,
+        }
+        if dry_run:
+            return order
+
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+            "qty": qty,
+            "side": side.lower(),
+            "type": "market",
+            "time_in_force": tif,
+        }
+        if sl is not None or tp is not None:
+            params["order_class"] = "bracket"
+            if tp is not None:
+                params["take_profit"] = {"limit_price": tp}
+            if sl is not None:
+                params["stop_loss"] = {"stop_price": sl}
+        try:
+            result = self.api.submit_order(**params)
+            order["id"] = getattr(result, "id", None)
+            order["status"] = getattr(result, "status", "")
+        except Exception as e:  # pragma: no cover - runtime logging
+            self.log.error("Order submission failed: %s", e)
+            raise
+        return order

--- a/SmartCFDTradingAgent/pipeline.py
+++ b/SmartCFDTradingAgent/pipeline.py
@@ -395,6 +395,11 @@ def run_cycle(
     dry_run: bool = False,
 ):
     equity = qty
+    if broker is not None and hasattr(broker, "get_equity"):
+        try:
+            equity = float(broker.get_equity())
+        except Exception as e:
+            log.error("Broker equity fetch failed: %s", e)
     if not watch:
         log.info("Watchlist empty – skipping cycle.")
         return
@@ -700,7 +705,7 @@ def main():
     ap.add_argument("--tz", default="Europe/Dublin")
     ap.add_argument("--ml-model", help="Path to trained ML model for signal blending")
     ap.add_argument("--ml-threshold", type=float, default=0.6, help="Probability threshold for ML override")
-    ap.add_argument("--broker", choices=["manual"], default="manual")
+    ap.add_argument("--broker", choices=["manual", "alpaca"], default="manual")
     ap.add_argument("--dry-run", action="store_true")
     # Caps & budgets
     ap.add_argument("--max-trades", type=int, default=999)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-dotenv>=1.0",
     "streamlit>=1.30",
     "tzdata>=2024.1",
+    "alpaca-trade-api>=3.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ yfinance==0.2.40
 pandas_market_calendars==4.4.0
 requests==2.32.3
 python-dotenv==1.0.1
+alpaca-trade-api==3.1.1
 pytest==8.3.2
 ruff==0.6.2
 black==24.4.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_alpaca_broker.py
+++ b/tests/test_alpaca_broker.py
@@ -1,0 +1,29 @@
+import types
+
+from SmartCFDTradingAgent.brokers import get_broker, AlpacaBroker
+import SmartCFDTradingAgent.brokers.alpaca as alpaca
+
+
+class DummyAPI:
+    def __init__(self, *args, **kwargs):
+        self.orders = []
+
+    def get_account(self):
+        return types.SimpleNamespace(equity="1000")
+
+    def submit_order(self, **kwargs):
+        self.orders.append(kwargs)
+        return types.SimpleNamespace(id="1", status="accepted")
+
+
+def test_alpaca_broker_submit_and_equity(monkeypatch):
+    dummy = DummyAPI()
+    monkeypatch.setattr(
+        alpaca, "tradeapi", types.SimpleNamespace(REST=lambda *a, **kw: dummy)
+    )
+    broker = get_broker("alpaca")
+    assert isinstance(broker, AlpacaBroker)
+    assert broker.get_equity() == 1000.0
+    res = broker.submit_order("AAPL", "buy", 1)
+    assert res["symbol"] == "AAPL"
+    assert dummy.orders[0]["symbol"] == "AAPL"


### PR DESCRIPTION
## Summary
- implement AlpacaBroker using `alpaca-trade-api` for account equity retrieval and order submission
- expose Alpaca broker and allow `--broker alpaca` in pipeline
- add tests for Alpaca broker and ensure package path is available in tests

## Testing
- `pip install alpaca-trade-api==3.1.1` *(fails: Could not find a version that satisfies the requirement)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42e9cf9648330961fd1881fa9455f