### PR TITLE
Use timezone-aware UTC timestamps for manual broker

### DIFF
--- a/SmartCFDTradingAgent/brokers/manual.py
+++ b/SmartCFDTradingAgent/brokers/manual.py
@@ -48,7 +48,7 @@ class ManualBroker(Broker):
         except Exception as e:  # pragma: no cover - logging only
             self.log.error("Telegram send failed: %s", e)
 
-        fname = f"{dt.datetime.utcnow().isoformat().replace(':','-')}_{symbol}_{side}.json"
+        fname = f"{dt.datetime.now(dt.timezone.utc).isoformat().replace(':','-')}_{symbol}_{side}.json"
         path = self.ticket_dir / fname
         try:
             path.write_text(json.dumps(ticket), encoding="utf-8")


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` with `datetime.now(dt.timezone.utc)` when generating manual broker ticket names

## Testing
- `pytest tests/test_manual_broker.py::test_manual_broker_ticket_creation -q`


------
https://chatgpt.com/codex/tasks/task_e_68b432a993608330a6d8ae07bd0bb755