### PR TITLE
Use timezone-aware timestamp in trade logger

### DIFF
--- a/SmartCFDTradingAgent/utils/trade_logger.py
+++ b/SmartCFDTradingAgent/utils/trade_logger.py
@@ -2,7 +2,7 @@ import csv
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict
-from datetime import datetime
+from datetime import datetime, timezone
 
 STORE = Path(__file__).resolve().parent.parent / "storage"
 STORE.mkdir(exist_ok=True)
@@ -59,7 +59,7 @@ def log_trade(row: Dict[str, Any]) -> None:
     """
     data = {k: row.get(k) for k in FIELDS}
     if not data.get("time"):
-        data["time"] = datetime.utcnow().isoformat(timespec="seconds")
+        data["time"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     # CSV
     new_file = not CSV_PATH.exists()


### PR DESCRIPTION
## Summary
- replace naive datetime.utcnow usage with timezone-aware datetime.now(timezone.utc)
- import timezone for UTC timestamps

## Testing
- `pytest tests/test_pipeline_logging.py::test_dry_run_cycle_logging_and_summary -q`


------
https://chatgpt.com/codex/tasks/task_e_68b432aa88fc8330b2461a1a7af91699