### PR TITLE
docs: clarify python version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Rank assets, generate signals, and send manual execution alerts via Telegram (wi
 
 See [AGENTS.md](AGENTS.md) for environment setup, linting, formatting, testing, and smoke/backtest instructions.
 
+This project targets Python 3.11–3.12 where pre-built pandas wheels are available.
+Windows users running Python 3.13 must install MSVC Build Tools to compile pandas or
+downgrade Python to 3.12/3.11.
+
 ## .env configuration
 Create a bot with @BotFather and copy `.env.example` to `.env` (do not commit):
 


### PR DESCRIPTION
## Summary
- document that the project targets Python 3.11–3.12 where pandas wheels are available
- note that Windows users on Python 3.13 need MSVC Build Tools or should downgrade

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement alpaca-trade-api==3.1.1)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b432ab8c848330bb8bbd14b675e2db