### PR TITLE
docs: clarify scheduler env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ Additional optional settings are available in `.env.example` such as
 `SKIP_SSL_VERIFY`, `RISK_PCT`, `MAX_POSITIONS`, `MAX_DAILY_LOSS_PCT`,
 `MARKET_GATE`, and `ALLOW_FRACTIONAL`.
 
+### Scheduler environments
+When running from Windows Task Scheduler or cron, ensure the job starts in the
+project root so the `.env` file is discovered.  These schedulers launch with a
+minimal environment, so credentials may need to be exported explicitly.
+
+Example cron entry invoking a one-off Telegram test:
+
+```
+* * * * * cd /path/to/SmartCFDTradingAgent_Revolut && \
+TELEGRAM_BOT_TOKEN=123456:ABC-XYZ TELEGRAM_CHAT_ID=123456789 \
+python -c "from SmartCFDTradingAgent.utils.telegram import send; send('test')"
+```
+
+Windows Task Scheduler users can set **Start in** to the project root and
+include environment variables in the command:
+
+```
+cmd /c "set TELEGRAM_BOT_TOKEN=123456:ABC-XYZ && set TELEGRAM_CHAT_ID=123456789 && python -c \"from SmartCFDTradingAgent.utils.telegram import send; send('test')\""
+```
+
 ## Asset categories
 Tickers are grouped into asset classes in `SmartCFDTradingAgent/assets.yml` (e.g. `crypto`, `equity`, `forex`, `commodity`).
 These categories drive per-class alert caps and risk budgets via the `class_caps` and


### PR DESCRIPTION
## Summary
- Explain that scheduled jobs must run from the repo root so `.env` loads
- Show cron and Task Scheduler examples with `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`

## Testing
- `TELEGRAM_BOT_TOKEN=foo TELEGRAM_CHAT_ID=123 python -c "from SmartCFDTradingAgent.utils.telegram import send; send('test')"` *(fails: HTTPSConnectionPool(host='api.telegram.org', port=443): Max retries exceeded with url: /botfoo/sendMessage (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*
- `TELEGRAM_DISABLE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b432acbf448330a007359888262de8