### PR TITLE
chore: remove streamlit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "requests>=2.32",
     "pandas_market_calendars>=4.4",
     "python-dotenv>=1.0",
-    "streamlit>=1.30",
     "tzdata>=2024.1",
     "alpaca-trade-api>=3.1",
 ]


### PR DESCRIPTION
## Summary
- remove streamlit from project dependencies

## Testing
- `pip uninstall -y streamlit`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b43bb37da48330ac8b26e2a9f71484