### PR TITLE
Use logger instead of print and update tests

### DIFF
--- a/SmartCFDTradingAgent/pipeline.py
+++ b/SmartCFDTradingAgent/pipeline.py
@@ -763,8 +763,10 @@ def main():
 
     if args.show_decisions > 0:
         rows = read_last_decisions(args.show_decisions)
-        msg = format_decisions(rows); print(msg)
-        if args.to_telegram: safe_send(msg)
+        msg = format_decisions(rows)
+        log.info(msg)
+        if args.to_telegram:
+            safe_send(msg)
         return
     if args.daily_summary:
         send_daily_summary(args.tz); return
@@ -776,7 +778,8 @@ def main():
         if isinstance(watch, str):
             watch = watch.split()
         if not watch:
-            print("Config missing 'watch' list."); sys.exit(2)
+            log.error("Config missing 'watch' list.")
+            sys.exit(2)
         model_cfg = None
         ml_path = cfg.get("ml_model", args.ml_model)
         if ml_path:
@@ -823,7 +826,7 @@ def main():
         return
 
     if not args.watch:
-        print("Error: --watch is required for normal run.")
+        log.error("Error: --watch is required for normal run.")
         sys.exit(2)
 
     model = None

--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -1,5 +1,6 @@
 import csv
 import sqlite3
+import sys
 import pandas as pd
 
 from SmartCFDTradingAgent import pipeline
@@ -71,3 +72,13 @@ def test_dry_run_cycle_logging_and_summary(monkeypatch, tmp_path):
     cur.execute("SELECT ticker FROM trades")
     assert cur.fetchone()[0] == "AAA"
     conn.close()
+
+
+def test_show_decisions_logs(monkeypatch, caplog):
+    monkeypatch.setattr(pipeline, "read_last_decisions", lambda n: [])
+    monkeypatch.setattr(pipeline, "format_decisions", lambda rows: "No decisions")
+    monkeypatch.setattr(pipeline, "safe_send", lambda msg: None)
+    monkeypatch.setattr(sys, "argv", ["prog", "--show-decisions", "1"])
+    with caplog.at_level("INFO"):
+        pipeline.main()
+    assert "No decisions" in caplog.text


### PR DESCRIPTION
## Summary
- Replace print statements in pipeline with logger calls
- Add test ensuring CLI decision output uses logger

## Testing
- `pytest tests/test_pipeline_logging.py` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b43bb879188330b191058566b99dc2