### PR TITLE
Add conditional venv activation and Python check for scripts

### DIFF
--- a/scripts/crypto_loop.sh
+++ b/scripts/crypto_loop.sh
@@ -2,8 +2,10 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
-# shellcheck disable=SC1091
-source venv/bin/activate
+if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source venv/bin/activate
+fi
 export CURL_CA_BUNDLE=
 export YF_DISABLE_CURL=1
 python -m SmartCFDTradingAgent.pipeline --config configs/crypto.yml --profile crypto_1h "$@"

--- a/scripts/equities_loop.sh
+++ b/scripts/equities_loop.sh
@@ -2,8 +2,10 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
-# shellcheck disable=SC1091
-source venv/bin/activate
+if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source venv/bin/activate
+fi
 export CURL_CA_BUNDLE=
 export YF_DISABLE_CURL=1
 python -m SmartCFDTradingAgent.pipeline --config configs/equities.yml --profile equities_daily "$@"

--- a/scripts/market_loop.sh
+++ b/scripts/market_loop.sh
@@ -2,6 +2,8 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
-# shellcheck disable=SC1091
-source venv/bin/activate
-scripts/run_bot.sh --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000
+if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source venv/bin/activate
+fi
+scripts/run_bot.sh --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000 "$@"

--- a/scripts/nightly.sh
+++ b/scripts/nightly.sh
@@ -2,8 +2,10 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
-# shellcheck disable=SC1091
-source venv/bin/activate
+if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source venv/bin/activate
+fi
 
 # Walk-forward (equities per-ticker, daily)
 python -m SmartCFDTradingAgent.walk_forward --watch SPY QQQ DIA IWM --interval 1d --years 3 --train-months 6 --test-months 1 --per-ticker

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -8,4 +8,8 @@ if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
 fi
 export CURL_CA_BUNDLE=
 export YF_DISABLE_CURL=1
+if ! command -v python >/dev/null 2>&1; then
+  echo "Error: Python executable not found. Please install Python and ensure it is in your PATH." >&2
+  exit 1
+fi
 python -m SmartCFDTradingAgent.pipeline "$@"


### PR DESCRIPTION
## Summary
- Mirror conditional virtualenv activation in crypto, equities, market, and nightly loop scripts
- Fail fast with a clear error if Python is missing when running the bot
- Forward extra args from `market_loop.sh` to `run_bot.sh`

## Testing
- `bash scripts/market_loop.sh --dry-run` *(fails: ModuleNotFoundError: dotenv)*
- `pytest` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68b43bba2ffc8330a30750503bb70b22