### PR TITLE
feat: activate venv and check python in market loop script

### DIFF
--- a/scripts/market_loop.cmd
+++ b/scripts/market_loop.cmd
@@ -1,9 +1,18 @@
 @echo off
-setlocal
-cd /d C:\Projects\SmartCFDTradingAgent_Revolut
+setlocal enabledelayedexpansion
+cd /d %~dp0\..
 
-REM Activate venv
-call venv\Scripts\activate
+REM Optionally activate virtual environment
+if not defined VIRTUAL_ENV (
+  if exist venv\Scripts\activate.bat call venv\Scripts\activate.bat
+)
+
+REM Ensure Python is available
+where python >nul 2>&1
+if errorlevel 1 (
+  echo Python could not be located. Please install Python or ensure it is on your PATH.
+  exit /b 1
+)
 
 REM Run equities during market window (Sharpe top-4, cap 2 suggestions)
 REM You can tweak symbols/ADX/interval as you like.


### PR DESCRIPTION
## Summary
- add optional venv activation to Windows market loop script
- fail fast with clear message if Python can't be found

## Testing
- `scripts/market_loop.cmd --dry-run` *(fails: command not found - requires Windows)*
- `pytest` *(fails: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68b43d3105fc83309801bd22333745e2