### PR TITLE
test: cover alpaca equity error path

### DIFF
--- a/tests/test_alpaca_broker.py
+++ b/tests/test_alpaca_broker.py
@@ -1,6 +1,11 @@
+import sys
 import types
 
-from SmartCFDTradingAgent.brokers import get_broker, AlpacaBroker
+# stub requests to avoid optional dependency during import
+sys.modules.setdefault("requests", types.SimpleNamespace(post=lambda *a, **kw: None))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+
+from SmartCFDTradingAgent.brokers.alpaca import AlpacaBroker
 import SmartCFDTradingAgent.brokers.alpaca as alpaca
 
 
@@ -21,9 +26,31 @@ def test_alpaca_broker_submit_and_equity(monkeypatch):
     monkeypatch.setattr(
         alpaca, "tradeapi", types.SimpleNamespace(REST=lambda *a, **kw: dummy)
     )
-    broker = get_broker("alpaca")
+    broker = AlpacaBroker()
     assert isinstance(broker, AlpacaBroker)
     assert broker.get_equity() == 1000.0
     res = broker.submit_order("AAPL", "buy", 1)
     assert res["symbol"] == "AAPL"
     assert dummy.orders[0]["symbol"] == "AAPL"
+
+
+class DummyAPIError:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_account(self):  # pragma: no cover - exercised in test
+        raise RuntimeError("boom")
+
+    def submit_order(self, **kwargs):  # pragma: no cover - unused
+        return types.SimpleNamespace(id="1", status="accepted")
+
+
+def test_alpaca_broker_get_equity_error(monkeypatch, caplog):
+    dummy = DummyAPIError()
+    monkeypatch.setattr(
+        alpaca, "tradeapi", types.SimpleNamespace(REST=lambda *a, **kw: dummy)
+    )
+    broker = AlpacaBroker()
+    with caplog.at_level("ERROR", logger="alpaca-broker"):
+        assert broker.get_equity() is None
+    assert "Account retrieval failed" in caplog.text


### PR DESCRIPTION
## Summary
- ensure AlpacaBroker.get_equity logs and returns None on API errors
- add unit test covering get_account failure

## Testing
- `pytest tests/test_broker_equity.py -q`
- `pytest tests/test_alpaca_broker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43d2f611c83308584b34c8b7ef9f7