### PR TITLE
Use logger for pipeline summary and adjust tests

### DIFF
--- a/SmartCFDTradingAgent/pipeline.py
+++ b/SmartCFDTradingAgent/pipeline.py
@@ -683,6 +683,7 @@ def run_cycle(
     if limits_hit:
         summary += " | limits: " + ",".join(sorted(limits_hit))
     safe_send(summary)
+    log.info(summary)
     if not dry_run:
         try:
             from SmartCFDTradingAgent.walk_forward import retrain_from_trade_log


### PR DESCRIPTION
## Summary
- log cycle summary via logger instead of print
- update pipeline logging tests to capture log output and stub external dependencies

## Testing
- `pytest tests/test_pipeline_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_68b43d3270c8833095776ea5ae6997de