### PR TITLE
chore: ignore market and crypto loop logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ SmartCFDTradingAgent/storage/
 SmartCFDTradingAgent/storage/decision_log.csv
 pnl_log.csv
 SmartCFDTradingAgent/storage/cache/
+market_loop.log
+crypto_loop.log
 
 # Databases
 *.sqlite

--- a/market_loop.log
+++ b/market_loop.log
@@ -1,8 +1,0 @@
-'/c' is not recognized as an internal or external command,
-operable program or batch file.
-Traceback (most recent call last):
-  File "<frozen runpy>", line 198, in _run_module_as_main
-  File "<frozen runpy>", line 88, in _run_code
-  File "C:\Projects\SmartCFDTradingAgent_Revolut\SmartCFDTradingAgent\pipeline.py", line 9, in <module>
-    from dotenv import load_dotenv
-ModuleNotFoundError: No module named 'dotenv'


### PR DESCRIPTION
## Summary
- remove `market_loop.log` from version control
- ignore `market_loop.log` and `crypto_loop.log`

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b460f753b4833082ab52f7c923b54f