### PR TITLE
test: assign indicators module directly

### DIFF
--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -45,12 +45,9 @@ sys.modules.setdefault(
     "SmartCFDTradingAgent.position",
     types.SimpleNamespace(qty_from_atr=lambda *a, **k: 1),
 )
-sys.modules.setdefault(
-    "SmartCFDTradingAgent.indicators",
-    types.SimpleNamespace(
-        adx=lambda *a, **k: FakeSeries([30]),
-        atr=lambda *a, **k: FakeSeries([1, 1]),
-    ),
+sys.modules["SmartCFDTradingAgent.indicators"] = types.SimpleNamespace(
+    adx=lambda *a, **k: FakeSeries([30]),
+    atr=lambda *a, **k: FakeSeries([1, 1]),
 )
 
 from SmartCFDTradingAgent import pipeline


### PR DESCRIPTION
## Summary
- replace `sys.modules.setdefault("SmartCFDTradingAgent.indicators", ...)` with direct assignment to ensure indicator stubs are always provided in pipeline logging tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b460f49d5c8330a5f3f89517393547