### PR TITLE
chore: upgrade alpaca-trade-api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pandas_market_calendars>=4.4",
     "python-dotenv>=1.0",
     "tzdata>=2024.1",
-    "alpaca-trade-api>=3.1",
+    "alpaca-trade-api>=3.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ yfinance==0.2.40
 pandas_market_calendars==4.4.0
 requests==2.32.3
 python-dotenv==1.0.1
-alpaca-trade-api==3.1.1
+alpaca-trade-api==3.2.0
 pytest==8.3.2
 ruff==0.6.2
 black==24.4.2


### PR DESCRIPTION
## Summary
- bump alpaca-trade-api to 3.2.0 to pick up aiohttp>=3.9 with wheels for multidict>=6
- rely on transitive aiohttp/multidict versions instead of explicit pins

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.2; proxy connection 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b46125de648330af137d19d53fca36