### PR TITLE
chore: set python 3.10-3.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Rank assets, generate signals, and send manual execution alerts via Telegram (wi
 
 See [AGENTS.md](AGENTS.md) for environment setup, linting, formatting, testing, and smoke/backtest instructions.
 
-This project targets Python 3.11–3.12 where pre-built pandas wheels are available.
-Windows users running Python 3.13 must install MSVC Build Tools to compile pandas or
-downgrade Python to 3.12/3.11.
+This project targets Python 3.10–3.11 where pre-built pandas wheels are available.
+Windows users running Python 3.12+ must install MSVC Build Tools to compile pandas or
+downgrade Python to 3.11/3.10.
 
 ## .env configuration
 Create a bot with @BotFather and copy `.env.example` to `.env` (do not commit):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "SmartCFDTradingAgent"
 version = "0.1.0"
 description = "Smart CFD Trading Agent"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 authors = [{name = "SmartCFDTradingAgent Developers"}]
 license = {text = "MIT"}
 classifiers = [


### PR DESCRIPTION
## Summary
- restrict supported Python to 3.10-3.11
- document version constraints in README

## Testing
- `pytest` (Python 3.10) *(fails: No module named 'pandas')*
- `pytest` (Python 3.11) *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b460f8df8883308b9fbd065ca8d1bb