### PR TITLE
Forward extra CLI flags and default dry-run in market loop scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ tail -n 20 SmartCFDTradingAgent/storage/decision_log.csv
 
 The `scripts` directory contains Unix-friendly `.sh` helpers mirroring the Windows `.cmd` files.
 
+Both `market_loop.cmd` and `market_loop.sh` forward any extra CLI flags to the
+underlying `run_bot` call and include `--dry-run` by default to avoid placing
+real orders. Remove `--dry-run` if you intend to trade live and pass additional
+options at invocation time, for example:
+
+```
+scripts/market_loop.cmd --force
+scripts/market_loop.sh --force
+```
+
 ### Cron (Unix)
 Schedule runs with `crontab -e`. For example, to execute the market loop at 14:30 UTC every weekday:
 

--- a/scripts/market_loop.cmd
+++ b/scripts/market_loop.cmd
@@ -16,6 +16,6 @@ if errorlevel 1 (
 
 REM Run equities during market window (Sharpe top-4, cap 2 suggestions)
 REM You can tweak symbols/ADX/interval as you like.
-scripts\run_bot.cmd --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000
+scripts\run_bot.cmd --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000 --dry-run %*
 
 endlocal

--- a/scripts/market_loop.sh
+++ b/scripts/market_loop.sh
@@ -6,4 +6,4 @@ if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
   # shellcheck disable=SC1091
   source venv/bin/activate
 fi
-scripts/run_bot.sh --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000 "$@"
+scripts/run_bot.sh --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000 --dry-run "$@"


### PR DESCRIPTION
## Summary
- Forward additional CLI flags to `run_bot` from `market_loop.cmd` and `market_loop.sh`
- Enable `--dry-run` by default to prevent accidental live trades
- Document script flag forwarding and default dry-run usage in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.2 due to proxy issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b460f5cf1c8330b4cf6458f4a5bddf