### PR TITLE
feat: check python availability in run_bot

### DIFF
--- a/scripts/run_bot.cmd
+++ b/scripts/run_bot.cmd
@@ -1,9 +1,21 @@
 @echo off
 setlocal enabledelayedexpansion
 cd /d %~dp0\..
+
+REM Optionally activate virtual environment
 if not defined VIRTUAL_ENV (
-  if exist venv\Scripts\activate.bat call venv\Scripts\activate.bat
+  if exist venv\Scripts\activate.bat (
+    call venv\Scripts\activate.bat
+  )
 )
+
+REM Ensure Python is available
+where python >nul 2>&1
+if errorlevel 1 (
+  echo Python could not be located. Please install Python or ensure it is on your PATH.
+  exit /b 1
+)
+
 set "CURL_CA_BUNDLE="
 set "YF_DISABLE_CURL=1"
 python -m SmartCFDTradingAgent.pipeline %*


### PR DESCRIPTION
## Summary
- ensure run_bot.cmd only activates venv if `venv\Scripts\activate.bat` exists
- add Python availability check with clear error message

## Testing
- `cmd.exe /c scripts/run_bot.cmd` *(fails: command not found)*
- `mkdir -p venv/Scripts && printf "@echo off\n" > venv/Scripts/activate.bat && cmd.exe /c scripts/run_bot.cmd` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b461459d1483309863f156855b8ffc