### PR TITLE
test: monkeypatch atr in pipeline logging test

### DIFF
--- a/tests/test_pipeline_logging.py
+++ b/tests/test_pipeline_logging.py
@@ -84,6 +84,7 @@ def test_dry_run_cycle_logging_and_summary(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(pipeline, "generate_signals", lambda price, **k: {list(price.keys())[0]: "Buy"})
     monkeypatch.setattr(pipeline, "qty_from_atr", lambda atr, equity, risk: 1)
     monkeypatch.setattr(pipeline, "_adx", lambda *a, **k: FakeSeries([30]))
+    monkeypatch.setattr(pipeline, "_atr", lambda *a, **k: FakeSeries([1, 1]), raising=False)
 
     def fake_backtest(price, base_sig, **kwargs):
         pnl = {"cum_return": FakeSeries([1, 1.1])}


### PR DESCRIPTION
## Summary
- monkeypatch pipeline._atr in logging test so ATR doesn't need real calculations

## Testing
- `pytest tests/test_pipeline_logging.py::test_dry_run_cycle_logging_and_summary -q`
- `pytest -q` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b4614420a48330896ee7af2a7cc6af