### PR TITLE
docs: remove AGENTS.md reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Rank assets, generate signals, and send manual execution alerts via Telegram (wi
 
 ## Developer setup
 
-See [AGENTS.md](AGENTS.md) for environment setup, linting, formatting, testing, and smoke/backtest instructions.
-
 This project targets Python 3.11–3.12 where pre-built pandas wheels are available.
 Windows users running Python 3.13 must install MSVC Build Tools to compile pandas or
 downgrade Python to 3.12/3.11.


### PR DESCRIPTION
## Summary
- remove AGENTS.md reference from README since file doesn't exist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b46124bac4833094e2c963140b50d7