### PR TITLE
Add Windows scheduling docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,9 @@ TELEGRAM_BOT_TOKEN=123456:ABC-XYZ TELEGRAM_CHAT_ID=123456789 \
 python -c "from SmartCFDTradingAgent.utils.telegram import send; send('test')"
 ```
 
-Windows Task Scheduler users can set **Start in** to the project root and
-include environment variables in the command:
-
-```
-cmd /c "set TELEGRAM_BOT_TOKEN=123456:ABC-XYZ && set TELEGRAM_CHAT_ID=123456789 && python -c \"from SmartCFDTradingAgent.utils.telegram import send; send('test')\""
-```
+Windows Task Scheduler users should set **Start in** to the project root and
+include environment variables in the command. See [Scheduling on Windows](#scheduling-on-windows)
+for a step-by-step guide and sample command.
 
 ## Asset categories
 Tickers are grouped into asset classes in `SmartCFDTradingAgent/assets.yml` (e.g. `crypto`, `equity`, `forex`, `commodity`).
@@ -136,5 +133,18 @@ Schedule runs with `crontab -e`. For example, to execute the market loop at 14:3
 30 14 * * 1-5 /path/to/SmartCFDTradingAgent_Revolut/scripts/market_loop.sh >> /path/to/market_loop.log 2>&1
 ```
 
-This entry invokes `market_loop.sh` with the same CLI options as its Windows counterpart. Adjust the schedule and paths to suit your environment.
+This entry invokes `market_loop.sh` with the same CLI options as its Windows counterpart. Adjust the schedule and paths to suit your environment. See [docs/linux-scheduling.md](docs/linux-scheduling.md) for more examples.
 
+### Scheduling on Windows
+1. Open **Task Scheduler** and choose **Create Basic Task...**.
+2. Select a trigger (daily, at startup, etc.) and proceed to the **Action** step.
+3. Set **Program/script** to `cmd` and **Add arguments** to:
+
+   ```
+   /c "set TELEGRAM_BOT_TOKEN=123456:ABC-XYZ && set TELEGRAM_CHAT_ID=123456789 && python -m SmartCFDTradingAgent.pipeline --config configs/crypto.yml --profile crypto_1h"
+   ```
+
+4. In **Start in**, browse to the project root (where `.env` resides).
+5. Finish the wizard and ensure the task runs under an account with the required permissions.
+
+The `set` commands above define environment variables for the task before launching Python. Adjust the command and schedule for your environment. See [docs/windows-scheduling.md](docs/windows-scheduling.md) for more examples.

--- a/docs/linux-scheduling.md
+++ b/docs/linux-scheduling.md
@@ -1,0 +1,14 @@
+# Linux Cron Scheduling
+
+Use `cron` to run the trading agent automatically on Unix-like systems.
+
+## Example
+Edit your crontab:
+```bash
+crontab -e
+```
+Add an entry to run the market loop at 14:30 UTC every weekday:
+```cron
+30 14 * * 1-5 /path/to/SmartCFDTradingAgent_Revolut/scripts/market_loop.sh >> /path/to/market_loop.log 2>&1
+```
+The entry changes to the project directory, loads the `.env` file, and runs the helper script. Customize paths, schedule, and command options for your environment.

--- a/docs/windows-scheduling.md
+++ b/docs/windows-scheduling.md
@@ -1,0 +1,16 @@
+# Windows Task Scheduler
+
+This guide walks through scheduling the trading agent on Windows using Task Scheduler.
+
+## Steps
+1. Open **Task Scheduler** and choose **Create Basic Task...**.
+2. Pick a trigger suitable for your run cadence (e.g., daily or at logon).
+3. In **Action**, select **Start a Program**.
+4. Set **Program/script** to `cmd` and **Add arguments** to:
+   ```
+   /c "set TELEGRAM_BOT_TOKEN=123456:ABC-XYZ && set TELEGRAM_CHAT_ID=123456789 && python -m SmartCFDTradingAgent.pipeline --config configs/crypto.yml --profile crypto_1h"
+   ```
+5. Set **Start in** to the project root so the `.env` file is found.
+6. Finish the wizard. Ensure the task runs under an account with network access and the necessary permissions.
+
+The `set` commands assign environment variables for the single run before launching Python. Edit the command, paths, and schedule as needed.


### PR DESCRIPTION
## Summary
- Document Windows Task Scheduler setup with environment variable sample
- Link to new scheduling guides for Windows and Linux

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b46152d36883308ff08493c2cf667b