### PR TITLE
Add tests for daily summary and reconciliation scripts

### DIFF
--- a/tests/test_daily_summary_script.py
+++ b/tests/test_daily_summary_script.py
@@ -1,0 +1,31 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_daily_summary(monkeypatch):
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "daily_summary.py"
+    stub = types.SimpleNamespace(send=lambda msg: None)
+    monkeypatch.setitem(sys.modules, "SmartCFDTradingAgent.utils.telegram", stub)
+    spec = importlib.util.spec_from_file_location("daily_summary", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, stub
+
+
+def test_daily_summary_sends_message(monkeypatch):
+    ds, stub = _load_daily_summary(monkeypatch)
+    monkeypatch.setattr(ds, "aggregate_trade_stats", lambda: {"wins": 2, "losses": 1, "open": 3})
+    sent = {}
+
+    def fake_send(msg: str) -> None:
+        sent["msg"] = msg
+
+    monkeypatch.setattr(stub, "send", fake_send)
+    ds.main()
+    assert "Wins: 2" in sent["msg"]
+    assert "Losses: 1" in sent["msg"]
+    assert "Open trades: 3" in sent["msg"]

--- a/tests/test_revolut_recon_script.py
+++ b/tests/test_revolut_recon_script.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from SmartCFDTradingAgent import revolut_recon as rr
+
+
+def test_recon_creates_output(tmp_path, monkeypatch):
+    decisions = tmp_path / "decision_log.csv"
+    decisions.write_text("ts,ticker,side,price\n2023-01-01T10:00:00,ABC,Buy,100\n")
+    trades = tmp_path / "trades.csv"
+    trades.write_text("timestamp,symbol,quantity,price\n2023-01-01T10:30:00,ABC,1,101\n")
+    monkeypatch.setattr(rr, "DECISIONS", decisions)
+    monkeypatch.setattr(rr, "STORE", tmp_path)
+    out = rr.recon(str(trades), "2023-01-01", window_min=90, to_telegram=False)
+    assert out.exists()
+    df = pd.read_csv(out)
+    assert df.loc[0, "match"] == "YES"
+    assert df.loc[0, "ex_price"] == 101.0


### PR DESCRIPTION
## Summary
- Add test ensuring `daily_summary` script formats summary message and sends via Telegram
- Add test verifying `revolut_recon.recon` processes CSV inputs and creates matched reconciliation output

## Testing
- `pytest tests/test_daily_summary_script.py tests/test_revolut_recon_script.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b461523770833099e61202dd6b6ea2