### PR TITLE
Use logging instead of print statements

### DIFF
--- a/SmartCFDTradingAgent/optimizer.py
+++ b/SmartCFDTradingAgent/optimizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import argparse, json, datetime as dt
+import logging
 from pathlib import Path
 import numpy as np, pandas as pd
 from SmartCFDTradingAgent.data_loader import get_price_data
@@ -7,6 +8,8 @@ from SmartCFDTradingAgent.indicators import ema, macd, adx
 
 STORE = Path(__file__).resolve().parent / "storage"
 STORE.mkdir(exist_ok=True)
+
+log = logging.getLogger(__name__)
 
 def backtest_simple(df: pd.DataFrame, adx_th: int, sl=0.02, tp=0.04, max_hold=5,
                     ema_fast=12, ema_slow=26) -> float:
@@ -69,7 +72,7 @@ def main():
     key = ",".join(sorted(args.watch)) + "|" + args.interval
     obj[key] = best
     params_path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
-    print("Saved params to", params_path, "for key", key, "=>", best)
+    log.info("Saved params to %s for key %s => %s", params_path, key, best)
 
 if __name__ == "__main__":
     main()

--- a/SmartCFDTradingAgent/rank_assets.py
+++ b/SmartCFDTradingAgent/rank_assets.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import logging
 from typing import Iterable, List
 
 import pandas as pd
 
 from SmartCFDTradingAgent.data_loader import get_price_data
+
+log = logging.getLogger(__name__)
 
 
 def top_n(
@@ -33,8 +36,10 @@ def top_n(
     try:
         df = get_price_data(tickers, start, end, interval="1d")
     except Exception as e:
-        print(
-            f"[rank_assets] daily ranking failed ({e}); returning unranked first {n}.",
+        log.error(
+            "daily ranking failed (%s); returning unranked first %s.",
+            e,
+            n,
         )
         return tickers[: min(n, len(tickers))]
 
@@ -94,7 +99,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         lookback=lookback,
         min_dollar_volume=min_dollar_volume,
     )
-    print(ranked)
+    log.info("%s", ranked)
 
 
 if __name__ == "__main__":

--- a/SmartCFDTradingAgent/revolut_recon.py
+++ b/SmartCFDTradingAgent/revolut_recon.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 import argparse, csv, math, datetime as dt
+import logging
 from pathlib import Path
 import pandas as pd
 
 ROOT = Path(__file__).resolve().parent
 STORE = ROOT / "storage"
 DECISIONS = STORE / "decision_log.csv"
+
+log = logging.getLogger(__name__)
 
 def _load_decisions(day: str) -> pd.DataFrame:
     if not DECISIONS.exists():
@@ -45,9 +48,7 @@ def _nearest_trade(trades: pd.DataFrame, tkr: str, side: str, t_ref: pd.Timestam
     return subset.sort_values("diff_min").iloc[0]
 
 def recon(csv_path: str, day: str, window_min: int = 90, to_telegram: bool = False) -> Path:
-    from SmartCFDTradingAgent.utils.logger import get_logger
     from SmartCFDTradingAgent.utils.telegram import send as tg_send
-    log = get_logger()
     dec = _load_decisions(day)
     trd = _load_revolut_csv(csv_path)
     trd = trd[trd["date"] == day]
@@ -86,7 +87,7 @@ def main():
     else:
         day = args.day
     out = recon(args.csv, day, args.window_min, args.to_telegram)
-    print("Saved", out)
+    log.info("Saved %s", out)
 
 if __name__ == "__main__":
     main()

--- a/SmartCFDTradingAgent/train_model.py
+++ b/SmartCFDTradingAgent/train_model.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 import pandas as pd
 
 from SmartCFDTradingAgent.ml_models import PriceDirectionModel
+
+log = logging.getLogger(__name__)
 
 ROOT = Path(__file__).resolve().parent
 STORE = ROOT / "storage"
@@ -29,7 +32,7 @@ def main() -> None:
     model = PriceDirectionModel()
     model.fit(df)
     model.save(args.output)
-    print(f"Model saved to {args.output}")
+    log.info("Model saved to %s", args.output)
 
 
 if __name__ == "__main__":

--- a/SmartCFDTradingAgent/utils/telegram.py
+++ b/SmartCFDTradingAgent/utils/telegram.py
@@ -9,7 +9,7 @@ import requests
 from dotenv import load_dotenv
 
 
-log = logging.getLogger("telegram")
+log = logging.getLogger(__name__)
 
 API = "https://api.telegram.org/bot{token}/sendMessage"
 TIMEOUT = 10
@@ -57,7 +57,7 @@ def _post(text: str, token: str, chat_id: str) -> bool:
             r = requests.post(url, data=data, timeout=TIMEOUT)
         except Exception as e:
             if attempt == 3:
-                print(f"[telegram] request error: {e}")
+                log.warning("[telegram] request error: %s", e)
                 return False
             time.sleep(1.5 * (attempt + 1))
             continue

--- a/SmartCFDTradingAgent/walk_forward.py
+++ b/SmartCFDTradingAgent/walk_forward.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse, datetime as dt, json, sqlite3
+import logging
 from pathlib import Path
 import pandas as pd
 from SmartCFDTradingAgent.data_loader import get_price_data
@@ -14,6 +15,8 @@ except Exception:  # pragma: no cover - model training optional
 
 STORE = Path(__file__).resolve().parent / "storage"
 STORE.mkdir(exist_ok=True)
+
+log = logging.getLogger(__name__)
 
 
 def _tz_naive_index(idx: pd.DatetimeIndex) -> pd.DatetimeIndex:
@@ -232,12 +235,12 @@ def main():
             best = optimize_walk_forward(one, args.train_months, args.test_months)
             key = f"{t}|{args.interval}"
             obj[key] = best
-            print("Walk-forward (per-ticker) saved:", key, "=>", best)
+            log.info("Walk-forward (per-ticker) saved: %s => %s", key, best)
     else:
         best = optimize_walk_forward(df, args.train_months, args.test_months)
         key = ",".join(sorted(args.watch)) + "|" + args.interval
         obj[key] = best
-        print("Walk-forward (group) saved:", key, "=>", best)
+        log.info("Walk-forward (group) saved: %s => %s", key, best)
 
     params_path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add module-level loggers across scripts and replace print calls with appropriate logging
- clean up Telegram utility to log request errors

## Testing
- `pip install numpy==1.26.4 pandas==2.2.2` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b461516e308330a948367f99331aec