### PR TITLE
Handle get_account errors in Alpaca broker

### DIFF
--- a/SmartCFDTradingAgent/brokers/alpaca.py
+++ b/SmartCFDTradingAgent/brokers/alpaca.py
@@ -39,11 +39,11 @@ class AlpacaBroker(Broker):
         except Exception as e:  # pragma: no cover - runtime logging
             self.log.error("Account retrieval failed: %s", e)
             return None
-
         try:
             return float(getattr(acct, "equity", 0.0))
-        except Exception:
-            return 0.0
+        except Exception as e:  # pragma: no cover - runtime logging
+            self.log.error("Invalid account equity: %s", e)
+            return None
 
     def submit_order(
         self,


### PR DESCRIPTION
## Summary
- improve AlpacaBroker.get_equity error handling with logging and None return on failures

## Testing
- ⚠️ `pytest tests/test_broker_equity.py -q` (skipped: No module named 'pandas')
- ✅ `pytest tests/test_alpaca_broker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b461508fe48330987e56e46c3a0142