### PR TITLE
Constrain Python versions and clarify installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 Rank assets, generate signals, and send manual execution alerts via Telegram (with SL/TP).
 
-## Developer setup
+## Installation
 
 See [AGENTS.md](AGENTS.md) for environment setup, linting, formatting, testing, and smoke/backtest instructions.
 
-This project targets Python 3.11–3.12 where pre-built pandas wheels are available.
-Windows users running Python 3.13 must install MSVC Build Tools to compile pandas or
-downgrade Python to 3.12/3.11.
+Only Python 3.10–3.11 are supported where pre-built pandas wheels are available.
+Python 3.13 requires building pandas from source, which this project does not document.
 
 ## .env configuration
 Create a bot with @BotFather and copy `.env.example` to `.env` (do not commit):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "SmartCFDTradingAgent"
 version = "0.1.0"
 description = "Smart CFD Trading Agent"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 authors = [{name = "SmartCFDTradingAgent Developers"}]
 license = {text = "MIT"}
 classifiers = [


### PR DESCRIPTION
## Summary
- Limit supported Python versions to 3.10–3.11 in project metadata
- Update README installation guidance to reflect 3.10–3.11 support and warn about Python 3.13 requiring manual pandas build

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies pandas, connection blocked)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b4614fd6a4833091b5637200e8d4d9