### PR TITLE
Restrict Python version support and document pandas wheel limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Rank assets, generate signals, and send manual execution alerts via Telegram (with SL/TP).
 
+## Installation
+
+Requires Python 3.10 or 3.11 (`>=3.10,<3.12`). Python 3.13 is unsupported because pandas wheels are unavailable.
+
 ## Developer setup
 
 See [AGENTS.md](AGENTS.md) for environment setup, linting, formatting, testing, and smoke/backtest instructions.
-
-This project targets Python 3.11–3.12 where pre-built pandas wheels are available.
-Windows users running Python 3.13 must install MSVC Build Tools to compile pandas or
-downgrade Python to 3.12/3.11.
 
 ## .env configuration
 Create a bot with @BotFather and copy `.env.example` to `.env` (do not commit):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "SmartCFDTradingAgent"
 version = "0.1.0"
 description = "Smart CFD Trading Agent"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 authors = [{name = "SmartCFDTradingAgent Developers"}]
 license = {text = "MIT"}
 classifiers = [


### PR DESCRIPTION
## Summary
- restrict supported Python to 3.10–3.11 in `pyproject.toml`
- add installation note that Python 3.13 lacks pandas wheels

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.2)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b46144f414833086c812585691fcd3