### PR TITLE
Ignore market loop log and capture scheduled output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ SmartCFDTradingAgent/logs/
 SmartCFDTradingAgent/storage/
 SmartCFDTradingAgent/storage/decision_log.csv
 pnl_log.csv
+market_loop.log
 SmartCFDTradingAgent/storage/cache/
 
 # Databases

--- a/market_loop.log
+++ b/market_loop.log
@@ -1,8 +1,0 @@
-'/c' is not recognized as an internal or external command,
-operable program or batch file.
-Traceback (most recent call last):
-  File "<frozen runpy>", line 198, in _run_module_as_main
-  File "<frozen runpy>", line 88, in _run_code
-  File "C:\Projects\SmartCFDTradingAgent_Revolut\SmartCFDTradingAgent\pipeline.py", line 9, in <module>
-    from dotenv import load_dotenv
-ModuleNotFoundError: No module named 'dotenv'

--- a/scripts/market_loop.cmd
+++ b/scripts/market_loop.cmd
@@ -2,6 +2,8 @@
 setlocal enabledelayedexpansion
 cd /d %~dp0\..
 
+set LOGFILE=market_loop.log
+
 REM Optionally activate virtual environment
 if not defined VIRTUAL_ENV (
   if exist venv\Scripts\activate.bat call venv\Scripts\activate.bat
@@ -16,6 +18,7 @@ if errorlevel 1 (
 
 REM Run equities during market window (Sharpe top-4, cap 2 suggestions)
 REM You can tweak symbols/ADX/interval as you like.
-scripts\run_bot.cmd --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000
+set ARGS=--watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000
+scripts\run_bot.cmd %ARGS% %* >> %LOGFILE% 2>&1
 
 endlocal

--- a/scripts/market_loop.sh
+++ b/scripts/market_loop.sh
@@ -2,8 +2,14 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
+
+LOGFILE="market_loop.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
 if [[ -z "$VIRTUAL_ENV" && -f "venv/bin/activate" ]]; then
   # shellcheck disable=SC1091
   source venv/bin/activate
 fi
-scripts/run_bot.sh --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 --max-trades 2 --grace 120 --risk 0.01 --equity 1000 "$@"
+
+scripts/run_bot.sh --watch SPY QQQ DIA IWM --size 4 --interval 1d --adx 15 \
+  --max-trades 2 --grace 120 --risk 0.01 --equity 1000 "$@"


### PR DESCRIPTION
## Summary
- stop tracking `market_loop.log` and add it to `.gitignore`
- ensure market loop scripts append their output to `market_loop.log`

## Testing
- `pip install python-dotenv` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b46123ef608330b976d48caddbfebc