### PR TITLE
Use project logger for telegram utility

### DIFF
--- a/SmartCFDTradingAgent/utils/telegram.py
+++ b/SmartCFDTradingAgent/utils/telegram.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 import os
 import time
-import json
-
 import requests
 from dotenv import load_dotenv
 
 from SmartCFDTradingAgent.utils.logger import get_logger
 
 
-log = logging.getLogger(__name__)
+log = get_logger("telegram")
 
 
 API = "https://api.telegram.org/bot{token}/sendMessage"


### PR DESCRIPTION
## Summary
- initialize the telegram utility logger through the shared get_logger helper
- remove an unused json import from the module

## Testing
- python -m SmartCFDTradingAgent.pipeline --help *(fails with existing SyntaxError in SmartCFDTradingAgent/rank_assets.py)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb1a5926483309912e316d3c57740