### PR TITLE
Improve Yahoo fallback for crypto data

### DIFF
--- a/SmartCFDTradingAgent/data_loader.py
+++ b/SmartCFDTradingAgent/data_loader.py
@@ -10,6 +10,7 @@ import logging
 
 import pandas as pd
 import yfinance as yf
+import requests
 
 from SmartCFDTradingAgent.utils.logger import get_logger
 
@@ -232,6 +233,62 @@ def _download(
     )
 
 
+_YF_SESSION: requests.Session | None = None
+
+
+def _get_yf_session() -> requests.Session:
+    global _YF_SESSION
+    if _YF_SESSION is None:
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": os.getenv(
+                    "YF_USER_AGENT",
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/122.0 Safari/537.36",
+                )
+            }
+        )
+        _YF_SESSION = session
+    return _YF_SESSION
+
+
+def _download_history(
+    ticker: str,
+    *,
+    start: str | None,
+    end: str | None,
+    interval: str,
+) -> pd.DataFrame | None:
+    """Fallback to ``Ticker.history`` for stubborn Yahoo responses."""
+
+    try:
+        history = yf.Ticker(ticker, session=_get_yf_session()).history(
+            start=start,
+            end=end,
+            interval=interval,
+            auto_adjust=False,
+            actions=False,
+            prepost=False,
+        )
+    except Exception as exc:
+        log.debug("Ticker.history failed for %s: %s", ticker, exc)
+        return None
+
+    if history is None or history.empty:
+        return None
+
+    history.index = pd.to_datetime(history.index)
+    history = history.sort_index()
+    expected_cols = [c for c in FIELDS_ORDER if c in history.columns]
+    if not expected_cols:
+        return None
+
+    history = history[expected_cols]
+    return pd.concat({ticker: history}, axis=1)
+
+
 def get_price_data(
     tickers: Iterable[str],
     start: str,
@@ -253,9 +310,13 @@ def get_price_data(
 
     if use_alpaca_crypto() and tickers and all(_is_crypto_symbol(t) for t in tickers):
         log.info("Fetching crypto data via Alpaca for tickers: %s", tickers)
-        return _get_crypto_data_alpaca(tickers, start, end, iv)
-    else:
-        _quiet_yf_logs()
+        try:
+            return _get_crypto_data_alpaca(tickers, start, end, iv)
+        except Exception as exc:
+            log.error("Alpaca crypto data fetch failed: %s", exc)
+            log.info("Falling back to Yahoo Finance for crypto data.")
+
+    _quiet_yf_logs()
 
     # ---------- Intraday path (per-ticker only) ----------
     if iv in INTRADAY:
@@ -290,6 +351,11 @@ def get_price_data(
                     except Exception:
                         pass
                     time.sleep(pause * attempt)
+            alt = _download_history(t, start=start, end=end, interval=iv)
+            if alt is not None and not alt.dropna(how="all").empty:
+                log.info("Fetched %s via yfinance.Ticker.history fallback", t)
+                _save_cache(f"{t}|history|{iv}|{start}|{end}", alt)
+                return t, alt, False
             return t, None, False
 
         start_t = time.time()
@@ -344,11 +410,19 @@ def get_price_data(
             d1 = _download(t, start=start, end=end, interval=iv, threads=False)
             d1 = _normalize_to_ticker_field(d1, [t])
             if d1 is None or d1.dropna(how="all").empty:
-                missing.append(t)
+                alt = _download_history(t, start=start, end=end, interval=iv)
+                if alt is None or alt.dropna(how="all").empty:
+                    missing.append(t)
+                    continue
+                frames.append(alt)
                 continue
             frames.append(d1)
         except Exception:
-            missing.append(t)
+            alt = _download_history(t, start=start, end=end, interval=iv)
+            if alt is None or alt.dropna(how="all").empty:
+                missing.append(t)
+                continue
+            frames.append(alt)
 
     if frames:
         out = pd.concat(frames, axis=1).sort_index()


### PR DESCRIPTION
## Summary
- add a persistent requests session with custom User-Agent for yfinance
- fall back to yfinance.Ticker.history when download() returns empty data
- cache successful history-based responses for reuse

## Testing
- pytest *(fails: test_broker_equity::test_run_cycle_uses_broker_equity, test_broker_equity::test_run_cycle_handles_none_equity, test_pipeline_logging::test_dry_run_cycle_logging_and_summary, test_reporting::test_digest_handles_missing_files, test_ssl_toggle::test_download_smoke[1])*

------
https://chatgpt.com/codex/tasks/task_e_68e14a129dbc8330b9644ddb0f78538c