### PR TITLE
Add CryptoCompare fallback for crypto pricing

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,5 +1,8 @@
 import pandas as pd
 import pytest
+import requests
+
+from SmartCFDTradingAgent import data_loader as dl
 from SmartCFDTradingAgent.data_loader import get_price_data
 
 
@@ -60,3 +63,228 @@ def test_get_price_data_cache_hit(monkeypatch, tmp_path, caplog):
     get_price_data(["AAA"], "2022-01-01", "2022-01-02", interval="1h", max_tries=1, pause=0)
     assert calls["n"] == 1
     assert any("Cache hit" in r.message for r in caplog.records)
+
+
+def test_coinbase_fallback(monkeypatch):
+    def fail_download(*_, **__):
+        raise Exception("primary download failed")
+
+    def fail_history(*_, **__):
+        return None
+
+    def fail_chart(*_, **__):
+        return None
+
+    def fake_coinbase(ticker, *, start, end, interval, cache_expire=None):
+        idx = pd.date_range(start, periods=2, freq="1h")
+        frame = pd.DataFrame(
+            {
+                "Open": [1.0, 2.0],
+                "High": [1.5, 2.5],
+                "Low": [0.5, 1.5],
+                "Close": [1.2, 2.2],
+                "Adj Close": [1.2, 2.2],
+                "Volume": [10.0, 20.0],
+            },
+            index=idx,
+        )
+        return pd.concat({ticker: frame}, axis=1)
+
+    monkeypatch.setattr(dl, "_download", fail_download)
+    monkeypatch.setattr(dl, "_download_history", fail_history)
+    monkeypatch.setattr(dl, "_download_chart", fail_chart)
+    monkeypatch.setattr(dl, "_download_coinbase", fake_coinbase)
+
+    df = get_price_data(["BTC-USD"], "2022-01-01", "2022-01-03", interval="1h", max_tries=1, pause=0)
+
+    assert not df.empty
+    assert ("BTC-USD", "Close") in df.columns
+
+
+def test_cryptocompare_fallback(monkeypatch):
+    def fail_download(*_, **__):
+        raise Exception("primary download failed")
+
+    def fail_history(*_, **__):
+        return None
+
+    def fail_chart(*_, **__):
+        return None
+
+    def fail_coinbase(*_, **__):
+        return None
+
+    def fake_cryptocompare(ticker, *, start, end, interval, cache_expire=None):
+        idx = pd.date_range(start, periods=2, freq="1h")
+        frame = pd.DataFrame(
+            {
+                "Open": [1.0, 2.0],
+                "High": [1.5, 2.5],
+                "Low": [0.5, 1.5],
+                "Close": [1.2, 2.2],
+                "Adj Close": [1.2, 2.2],
+                "Volume": [10.0, 20.0],
+            },
+            index=idx,
+        )
+        return pd.concat({ticker: frame}, axis=1)
+
+    monkeypatch.setattr(dl, "_download", fail_download)
+    monkeypatch.setattr(dl, "_download_history", fail_history)
+    monkeypatch.setattr(dl, "_download_chart", fail_chart)
+    monkeypatch.setattr(dl, "_download_coinbase", fail_coinbase)
+    monkeypatch.setattr(dl, "_download_cryptocompare", fake_cryptocompare)
+
+    df = get_price_data(["ETH-USD"], "2022-01-01", "2022-01-03", interval="1h", max_tries=1, pause=0)
+
+    assert not df.empty
+    assert ("ETH-USD", "Close") in df.columns
+
+
+def test_download_chart_proxy_retry(monkeypatch, caplog):
+    payload = {
+        "chart": {
+            "result": [
+                {
+                    "timestamp": [1_700_000_000, 1_700_003_600],
+                    "indicators": {
+                        "quote": [
+                            {
+                                "open": [1.0, 1.1],
+                                "high": [1.2, 1.3],
+                                "low": [0.9, 1.0],
+                                "close": [1.05, 1.15],
+                                "volume": [100, 110],
+                            }
+                        ],
+                        "adjclose": [
+                            {
+                                "adjclose": [1.05, 1.15],
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+    }
+
+    def fake_get_session(force_direct=False):
+        class FakeSession:
+            def get(self, *args, **kwargs):
+                if not force_direct:
+                    raise requests.exceptions.ProxyError("blocked")
+
+                class Resp:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return payload
+
+                return Resp()
+
+        return FakeSession()
+
+    monkeypatch.setattr(dl, "_get_yf_session", fake_get_session)
+
+    caplog.set_level("WARNING")
+    df = dl._download_chart("BTC-USD", start="2024-01-01", end="2024-01-02", interval="1h")
+
+    assert not df.empty
+    assert any("proxy" in record.message.lower() for record in caplog.records)
+
+
+def test_download_coinbase_proxy_retry(monkeypatch, caplog):
+    sample_rows = [
+        [1_700_000_000, 1.0, 1.5, 1.1, 1.2, 100.0],
+        [1_700_003_600, 1.1, 1.6, 1.2, 1.3, 110.0],
+    ]
+
+    def fake_coinbase_session(force_direct=False):
+        class FakeSession:
+            def get(self, *_, **__):
+                if not force_direct:
+                    raise requests.exceptions.ProxyError("proxy")
+
+                class Resp:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return sample_rows
+
+                return Resp()
+
+        return FakeSession()
+
+    monkeypatch.setattr(dl, "_get_coinbase_session", fake_coinbase_session)
+
+    caplog.set_level("WARNING")
+    df = dl._download_coinbase(
+        "BTC-USD",
+        start="2024-01-01",
+        end="2024-01-02",
+        interval="1h",
+    )
+
+    assert not df.empty
+    assert any("Coinbase API via proxy" in record.message for record in caplog.records)
+
+
+def test_download_cryptocompare_proxy_retry(monkeypatch, caplog):
+    payload = {
+        "Response": "Success",
+        "Data": {
+            "Data": [
+                {
+                    "time": 1_704_067_200,
+                    "open": 1.0,
+                    "high": 1.2,
+                    "low": 0.9,
+                    "close": 1.1,
+                    "volumeto": 100.0,
+                },
+                {
+                    "time": 1_704_070_800,
+                    "open": 1.1,
+                    "high": 1.3,
+                    "low": 1.0,
+                    "close": 1.2,
+                    "volumeto": 110.0,
+                },
+            ]
+        },
+    }
+
+    def fake_get_session(force_direct=False):
+        class FakeSession:
+            def __init__(self, direct):
+                self.direct = direct
+
+            def get(self, *args, **kwargs):
+                if not self.direct:
+                    raise requests.exceptions.ProxyError("blocked")
+
+                class Resp:
+                    def raise_for_status(self):
+                        return None
+
+                    def json(self):
+                        return payload
+
+                return Resp()
+
+        return FakeSession(force_direct)
+
+    monkeypatch.setattr(dl, "_get_cryptocompare_session", fake_get_session)
+
+    caplog.set_level("WARNING")
+    df = dl._download_cryptocompare(
+        "BTC-USD",
+        start="2024-01-01",
+        end="2024-01-02",
+        interval="1h",
+    )
+
+    assert not df.empty
+    assert any("cryptocompare via proxy failed" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
## Summary
- add a CryptoCompare session builder and candle downloader with caching and proxy-aware retries
- wire the CryptoCompare fallback into intraday and daily crypto salvage paths when Yahoo and Coinbase fail
- extend data loader tests to cover CryptoCompare fallback behavior and proxy retry logging

## Testing
- pytest tests/test_data_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68e14a129dbc8330b9644ddb0f78538c